### PR TITLE
Fix axe click on Android

### DIFF
--- a/frontend/app/components/PopupAnimation.tsx
+++ b/frontend/app/components/PopupAnimation.tsx
@@ -29,7 +29,7 @@ export const PopupAnimation: React.FC<PopupAnimationProps> = ({
 
   return (
     <Animated.View
-      className="absolute top-0 left-0 right-0 bottom-0 flex items-center justify-center z-[3]"
+      className="absolute top-0 left-0 right-0 bottom-0 flex items-center justify-center"
       style={{
         transform: [
           {


### PR DESCRIPTION
* Apparently z positioning was hindering the pressable ability of the axe. Not sure why but removing it allows axe to be clicked. Let me know if Z positioning was needed.