### PR TITLE
Fix burst font on Android

### DIFF
--- a/frontend/app/components/FlashBurst.tsx
+++ b/frontend/app/components/FlashBurst.tsx
@@ -292,7 +292,6 @@ const TextParticle: React.FC<TextParticleProps> = ({
           textShadowColor: "#000",
           textShadowOffset: { width: 1, height: 1 },
           textShadowRadius: 2,
-          fontWeight: "bold",
         }}
       >
         {text}


### PR DESCRIPTION
On Android the FlashBurst font was rendered with the default font and not with Pixels due to the usage of Bold