### PR TITLE
Update RN skia to align all libraries to 16kb page size requirement

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,7 +17,7 @@
         "@react-navigation/native": "^7.1.6",
         "@react-navigation/stack": "^7.4.2",
         "@sentry/react-native": "~6.14.0",
-        "@shopify/react-native-skia": "v2.0.0-next.4",
+        "@shopify/react-native-skia": "^2.2.9",
         "@walletconnect/core": "^2.20.3",
         "@walletconnect/react-native-compat": "^2.20.3",
         "@walletconnect/types": "^2.20.3",
@@ -4396,9 +4396,9 @@
       }
     },
     "node_modules/@shopify/react-native-skia": {
-      "version": "2.0.0-next.4",
-      "resolved": "https://registry.npmjs.org/@shopify/react-native-skia/-/react-native-skia-2.0.0-next.4.tgz",
-      "integrity": "sha512-NzvdgryRz6tkKMHgCChCKa3wXfN9TZhlV0/LrfIU/wKLC1uKgGXkoZgNz7Is0wwdhtao1JJJJ81fqHCGHgzk9g==",
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/@shopify/react-native-skia/-/react-native-skia-2.2.9.tgz",
+      "integrity": "sha512-Y05tM6fl6DJcqkLz4a3PRZK4F/CLSG0REa0q1nEU8fpa4WUn/CaILZB7iu/p/VpH2FVsR+ccHcfoX0RyAssOaA==",
       "license": "MIT",
       "dependencies": {
         "canvaskit-wasm": "0.40.0",
@@ -4410,7 +4410,7 @@
       "peerDependencies": {
         "react": ">=19.0",
         "react-native": ">=0.78",
-        "react-native-reanimated": "^3.0"
+        "react-native-reanimated": ">=3.19.1"
       },
       "peerDependenciesMeta": {
         "react-native": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,7 +27,7 @@
     "@react-navigation/native": "^7.1.6",
     "@react-navigation/stack": "^7.4.2",
     "@sentry/react-native": "~6.14.0",
-    "@shopify/react-native-skia": "v2.0.0-next.4",
+    "@shopify/react-native-skia": "^2.2.9",
     "@walletconnect/core": "^2.20.3",
     "@walletconnect/react-native-compat": "^2.20.3",
     "@walletconnect/types": "^2.20.3",


### PR DESCRIPTION
After upon further inspection only librnskia.so binary seemed to remain unaligned from the `arm64-v8a` and `x86_64` architectures. 

Based on this [PR](https://github.com/Shopify/react-native-skia/pull/3177) it seems that they have built skia with 16kb page size support in `2.0.6`.

Booted an emulator with 16kb page size and there is no warning about it anymore. The [`check_elf_alignement.sh`](https://cs.android.com/android/platform/superproject/main/+/main:system/extras/tools/check_elf_alignment.sh) script seems to agree.