### PR TITLE
Remove unwanted permissions

### DIFF
--- a/frontend/app.config.ts
+++ b/frontend/app.config.ts
@@ -32,6 +32,9 @@ const config: ExpoConfig = {
     },
     package: "com.starknet.pow",
     edgeToEdgeEnabled: true,
+    blockedPermissions: [
+      "android.permission.RECORD_AUDIO"
+    ]
   },
   web: {
     bundler: "metro",


### PR DESCRIPTION
Remove microphone permission which is added by default in `AndroidManifest.xml` when using expo audio