### PR TITLE
feat: Add pause/resume functionality for automated transaction speeds

### DIFF
--- a/frontend/app/components/initializers/StoreInitializer.tsx
+++ b/frontend/app/components/initializers/StoreInitializer.tsx
@@ -11,6 +11,7 @@ import { useAchievementsStore } from "@/app/stores/useAchievementsStore";
 import { useSoundStore, useSound } from "@/app/stores/useSoundStore";
 import { useTutorialStore } from "@/app/stores/useTutorialStore";
 import { useUpgradesStore } from "@/app/stores/useUpgradesStore";
+import { useTransactionPauseStore } from "@/app/stores/useTransactionPauseStore";
 
 const OnchainActionsInitializer = memo(() => {
   const { invokeCalls, waitForTransaction } = useStarknetConnector();
@@ -250,6 +251,16 @@ const UpgradesInitializer = memo(() => {
   return null;
 });
 
+const TransactionPauseInitializer = memo(() => {
+  const { initializePauseStore } = useTransactionPauseStore();
+
+  useEffect(() => {
+    initializePauseStore();
+  }, [initializePauseStore]);
+
+  return null;
+});
+
 export const StoreInitializer = memo(() => {
   return (
     <>
@@ -263,6 +274,7 @@ export const StoreInitializer = memo(() => {
       <GameStoreInitializer />
       <L2Initializer />
       <UpgradesInitializer />
+      <TransactionPauseInitializer />
     </>
   );
 });

--- a/frontend/app/components/store/TransactionUpgradeView.tsx
+++ b/frontend/app/components/store/TransactionUpgradeView.tsx
@@ -72,6 +72,7 @@ export const TransactionUpgradeView: React.FC<TransactionUpgradeViewProps> =
           nextCost={nextTxFeeCost}
           txId={props.txData.id}
           chainId={props.chainId}
+          isDapp={props.isDapp}
           onBuyPress={() => {
             if (props.isDapp) {
               dappFeeUpgrade(props.chainId, props.txData.id);

--- a/frontend/app/components/store/transactionUpgrade/TransactionUpgradeActions.tsx
+++ b/frontend/app/components/store/transactionUpgrade/TransactionUpgradeActions.tsx
@@ -23,8 +23,17 @@ type ActionsProps = {
 };
 
 export const TransactionUpgradeActions: React.FC<
-  ActionsProps & { txId?: number; chainId?: number }
-> = ({ locked, nextCost, onBuyPress, feeProps, speedProps, txId, chainId }) => {
+  ActionsProps & { txId?: number; chainId?: number; isDapp?: boolean }
+> = ({
+  locked,
+  nextCost,
+  onBuyPress,
+  feeProps,
+  speedProps,
+  txId,
+  chainId,
+  isDapp,
+}) => {
   // Enable tutorial only for first transaction (id: 0) on L1 (chainId: 0)
   const isFirstTransaction = txId === 0 && chainId === 0;
   const feeEnabled = feeProps !== undefined && !locked && isFirstTransaction;
@@ -71,6 +80,10 @@ export const TransactionUpgradeActions: React.FC<
             nextCost={speedProps.nextCost}
             onPress={speedProps.onPress}
             bgImage={"shop.tx.buy"}
+            chainId={chainId}
+            txId={txId}
+            isDapp={isDapp ?? false}
+            isSpeedUpgrade={true}
           />
         </View>
       )}

--- a/frontend/app/pages/settings/Main.tsx
+++ b/frontend/app/pages/settings/Main.tsx
@@ -15,6 +15,7 @@ import { useTutorialStore } from "../../stores/useTutorialStore";
 import { useGameStore } from "../../stores/useGameStore";
 import { useBalanceStore } from "../../stores/useBalanceStore";
 import { useTransactionsStore } from "../../stores/useTransactionsStore";
+import { useTransactionPauseStore } from "../../stores/useTransactionPauseStore";
 import { useL2Store } from "../../stores/useL2Store";
 import { useAchievementsStore } from "../../stores/useAchievementsStore";
 import { useUpgradesStore } from "../../stores/useUpgradesStore";
@@ -56,6 +57,7 @@ const SettingsMainSection: React.FC<SettingsMainSectionProps> = ({
     useBalanceStore.getState().resetBalance();
     useUpgradesStore.getState().resetUpgrades();
     useTransactionsStore.getState().resetTransactions();
+    useTransactionPauseStore.getState().resetPauseStore();
     useL2Store.getState().resetL2Store();
 
     // Reset achievements with current account

--- a/frontend/app/stores/useTransactionPauseStore.ts
+++ b/frontend/app/stores/useTransactionPauseStore.ts
@@ -1,0 +1,98 @@
+import { create } from "zustand";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+interface TransactionPauseState {
+  // Map: chainId -> txId -> isDapp -> boolean (paused state)
+  pausedTransactions: {
+    [chainId: number]: { [txId: number]: { [isDapp: string]: boolean } };
+  };
+  isInitialized: boolean;
+
+  // Actions
+  initializePauseStore: () => Promise<void>;
+  setPaused: (
+    chainId: number,
+    txId: number,
+    isDapp: boolean,
+    paused: boolean,
+  ) => Promise<void>;
+  isPaused: (chainId: number, txId: number, isDapp: boolean) => boolean;
+  resetPauseStore: () => Promise<void>;
+}
+
+const STORAGE_KEY = "transaction_pause_states";
+
+export const useTransactionPauseStore = create<TransactionPauseState>(
+  (set, get) => ({
+    pausedTransactions: {},
+    isInitialized: false,
+
+    initializePauseStore: async () => {
+      try {
+        const stored = await AsyncStorage.getItem(STORAGE_KEY);
+        if (stored) {
+          const parsedData = JSON.parse(stored);
+          set({ pausedTransactions: parsedData, isInitialized: true });
+        } else {
+          set({ isInitialized: true });
+        }
+      } catch (error) {
+        console.error("Failed to initialize pause store:", error);
+        set({ isInitialized: true });
+      }
+    },
+
+    setPaused: async (
+      chainId: number,
+      txId: number,
+      isDapp: boolean,
+      paused: boolean,
+    ) => {
+      const { pausedTransactions } = get();
+      const dappKey = isDapp ? "true" : "false";
+
+      const newPausedTransactions = { ...pausedTransactions };
+      if (!newPausedTransactions[chainId]) {
+        newPausedTransactions[chainId] = {};
+      }
+      if (!newPausedTransactions[chainId][txId]) {
+        newPausedTransactions[chainId][txId] = {};
+      }
+
+      newPausedTransactions[chainId][txId][dappKey] = paused;
+
+      set({ pausedTransactions: newPausedTransactions });
+
+      try {
+        await AsyncStorage.setItem(
+          STORAGE_KEY,
+          JSON.stringify(newPausedTransactions),
+        );
+      } catch (error) {
+        console.error("Failed to save pause state:", error);
+      }
+    },
+
+    isPaused: (chainId: number, txId: number, isDapp: boolean): boolean => {
+      const { pausedTransactions } = get();
+      const dappKey = isDapp ? "true" : "false";
+      return pausedTransactions[chainId]?.[txId]?.[dappKey] ?? false;
+    },
+
+    resetPauseStore: async () => {
+      // Clear all paused states
+      set({ pausedTransactions: {}, isInitialized: true });
+
+      // Clear from AsyncStorage
+      try {
+        await AsyncStorage.removeItem(STORAGE_KEY);
+      } catch (error) {
+        console.error("Failed to clear pause states from storage:", error);
+      }
+    },
+  }),
+);
+
+export const useTransactionPause = () => {
+  return useTransactionPauseStore();
+};

--- a/frontend/app/stores/useUpgradesStore.ts
+++ b/frontend/app/stores/useUpgradesStore.ts
@@ -10,6 +10,7 @@ import { useL2Store } from "./useL2Store";
 import { useTransactionsStore } from "./useTransactionsStore";
 import { useGameStore } from "./useGameStore";
 import { useOnchainActions } from "./useOnchainActions";
+import { useTransactionPauseStore } from "./useTransactionPauseStore";
 
 interface UpgradesState {
   // Map: chainId -> upgradeId -> Upgrade Level
@@ -403,6 +404,7 @@ export const useUpgradesStore = create<UpgradesState>((set, get) => ({
     useGameStore.getState().resetGameStore();
     useL2Store.getState().resetL2Store();
     useTransactionsStore.getState().resetTransactions();
+    useTransactionPauseStore.getState().resetPauseStore();
     get().resetUpgrades();
 
     set({


### PR DESCRIPTION
- Implement useTransactionPauseStore for persistent pause state management
- Add pause/play toggle button to max-level speed upgrades in UpgradeButton
- Integrate pause state checks in TxButtonInner animation logic
- Ensure pause states are reset when game is reset
- Store pause preferences in AsyncStorage for persistence across sessions