### PR TITLE
feat: Direct user to claim reward on Prestige

### DIFF
--- a/frontend/app/components/ClaimRewardModal.tsx
+++ b/frontend/app/components/ClaimRewardModal.tsx
@@ -24,7 +24,9 @@ const ClaimRewardModalComponent: React.FC = () => {
     const checkAndShowModal = async () => {
       if (currentPrestige >= 1 && !hasShownClaimModal) {
         try {
-          const rewardClaimedTxHash = await AsyncStorage.getItem("rewardClaimedTxHash");
+          const rewardClaimedTxHash = await AsyncStorage.getItem(
+            "rewardClaimedTxHash",
+          );
           if (rewardClaimedTxHash) {
             // User already claimed reward, don't show modal
             setShouldShow(false);
@@ -41,15 +43,14 @@ const ClaimRewardModalComponent: React.FC = () => {
         }
       }
     };
-    
+
     checkAndShowModal();
   }, [currentPrestige, hasShownClaimModal, setHasShownClaimModal]);
 
   const { navigate } = useNavigation();
   const handleClaim = () => {
     setShouldShow(false);
-    // TODO: Navigate to Settings with ClaimReward tab using event system
-    (navigate as any)("Settings",{ initialTab: "ClaimReward" });
+    (navigate as any)("Settings", { initialTab: "ClaimReward" });
   };
 
   const handleLater = () => {

--- a/frontend/app/components/ClaimRewardModal.tsx
+++ b/frontend/app/components/ClaimRewardModal.tsx
@@ -1,5 +1,6 @@
 import React, { memo, useEffect, useState } from "react";
 import { View, Text, Pressable } from "react-native";
+import { useNavigation } from "@react-navigation/native";
 import {
   Canvas,
   Image,
@@ -44,9 +45,11 @@ const ClaimRewardModalComponent: React.FC = () => {
     checkAndShowModal();
   }, [currentPrestige, hasShownClaimModal, setHasShownClaimModal]);
 
+  const { navigate } = useNavigation();
   const handleClaim = () => {
     setShouldShow(false);
     // TODO: Navigate to Settings with ClaimReward tab using event system
+    (navigate as any)("Settings",{ initialTab: "ClaimReward" });
   };
 
   const handleLater = () => {

--- a/frontend/app/components/ClaimRewardModal.tsx
+++ b/frontend/app/components/ClaimRewardModal.tsx
@@ -6,6 +6,7 @@ import {
   FilterMode,
   MipmapMode,
 } from "@shopify/react-native-skia";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 import { Window } from "./tutorial/Window";
 import { useUpgradesStore } from "../stores/useUpgradesStore";
 import { useImages } from "../hooks/useImages";
@@ -19,10 +20,28 @@ const ClaimRewardModalComponent: React.FC = () => {
 
   useEffect(() => {
     // Show modal when user reaches prestige 1 for the first time
-    if (currentPrestige >= 1 && !hasShownClaimModal) {
-      setShouldShow(true);
-      setHasShownClaimModal(true);
-    }
+    const checkAndShowModal = async () => {
+      if (currentPrestige >= 1 && !hasShownClaimModal) {
+        try {
+          const rewardClaimedTxHash = await AsyncStorage.getItem("rewardClaimedTxHash");
+          if (rewardClaimedTxHash) {
+            // User already claimed reward, don't show modal
+            setShouldShow(false);
+          } else {
+            // User hasn't claimed reward yet, show modal
+            setShouldShow(true);
+          }
+          setHasShownClaimModal(true);
+        } catch (error) {
+          console.error("Error checking rewardClaimedTxHash:", error);
+          // If there's an error reading AsyncStorage, show modal as fallback
+          setShouldShow(true);
+          setHasShownClaimModal(true);
+        }
+      }
+    };
+    
+    checkAndShowModal();
   }, [currentPrestige, hasShownClaimModal, setHasShownClaimModal]);
 
   const handleClaim = () => {

--- a/frontend/app/components/ClaimRewardModal.tsx
+++ b/frontend/app/components/ClaimRewardModal.tsx
@@ -1,0 +1,111 @@
+import React, { memo, useEffect, useState } from "react";
+import { View, Text, Pressable } from "react-native";
+import {
+  Canvas,
+  Image,
+  FilterMode,
+  MipmapMode,
+} from "@shopify/react-native-skia";
+import { Window } from "./tutorial/Window";
+import { useUpgradesStore } from "../stores/useUpgradesStore";
+import { useImages } from "../hooks/useImages";
+
+const ClaimRewardModalComponent: React.FC = () => {
+  const { currentPrestige, hasShownClaimModal, setHasShownClaimModal } =
+    useUpgradesStore();
+  const [shouldShow, setShouldShow] = useState(false);
+  const { getImage } = useImages();
+  const prestigeImage = getImage("tx.icon.lendme");
+
+  useEffect(() => {
+    // Show modal when user reaches prestige 1 for the first time
+    if (currentPrestige >= 1 && !hasShownClaimModal) {
+      setShouldShow(true);
+      setHasShownClaimModal(true);
+    }
+  }, [currentPrestige, hasShownClaimModal, setHasShownClaimModal]);
+
+  const handleClaim = () => {
+    setShouldShow(false);
+    // TODO: Navigate to Settings with ClaimReward tab using event system
+  };
+
+  const handleLater = () => {
+    setShouldShow(false);
+  };
+
+  if (!shouldShow) return null;
+
+  return (
+    <View className="absolute inset-0 z-[1002]">
+      {/* Dark overlay */}
+      <View className="absolute inset-0 bg-black/70" pointerEvents="auto" />
+
+      {/* Modal window */}
+      <View className="absolute inset-0 items-center justify-center">
+        <Window
+          style={{
+            width: 320,
+          }}
+        >
+          <View className="items-center px-4 py-4">
+            <Text className="text-[26px] font-Teatime text-yellow-400 mb-4 text-center">
+              Claim your Reward
+            </Text>
+
+            {/* Prestige 1 Icon */}
+            <View className="w-24 h-24 mb-4">
+              <Canvas style={{ width: 96, height: 96 }}>
+                {prestigeImage && (
+                  <Image
+                    image={prestigeImage}
+                    x={0}
+                    y={0}
+                    width={96}
+                    height={96}
+                    fit="contain"
+                    sampling={{
+                      filter: FilterMode.Nearest,
+                      mipmap: MipmapMode.Nearest,
+                    }}
+                  />
+                )}
+              </Canvas>
+            </View>
+
+            <Text className="text-[14px] font-Pixels text-gray-100 text-center mb-6 px-2 leading-5">
+              <Text className="text-yellow-400">Congratulations</Text> for
+              reaching Prestige 1. For your valiant efforts, you have earned{" "}
+              <Text className="text-purple-400">STRK tokens</Text>! Go to the
+              Settings Page to <Text className="text-yellow-400">claim</Text>!
+              Dont spend them all in one place ;)
+            </Text>
+
+            {/* Bottom Buttons */}
+            <View className="flex-row gap-4">
+              <Pressable
+                onPress={handleLater}
+                className="bg-gray-600 px-6 py-2 rounded-lg"
+              >
+                <Text className="text-white font-Pixels text-[14px]">
+                  Later
+                </Text>
+              </Pressable>
+
+              <Pressable
+                onPress={handleClaim}
+                className="bg-yellow-500 px-6 py-2 rounded-lg"
+              >
+                <Text className="text-black font-Pixels text-[14px]">
+                  Claim
+                </Text>
+              </Pressable>
+            </View>
+          </View>
+        </Window>
+      </View>
+    </View>
+  );
+};
+
+export const ClaimRewardModal = memo(ClaimRewardModalComponent);

--- a/frontend/app/navigation/RootNavigator.tsx
+++ b/frontend/app/navigation/RootNavigator.tsx
@@ -8,12 +8,10 @@ import { Header } from "../components/Header";
 import { InAppNotification } from "../components/InAppNotification";
 import { TutorialOverlay } from "../components/TutorialOverlay";
 import { RevertModal } from "../components/RevertModal";
-import { ClaimRewardModal } from "../components/ClaimRewardModal";
 import { LoadingScreen } from "../pages/LoadingScreen";
 
 import { useFocEngine } from "../context/FocEngineConnector";
 import { useTutorial } from "../stores/useTutorialStore";
-import { useStarknetConnector } from "../context/StarknetConnector";
 
 const Stack = createStackNavigator();
 
@@ -44,7 +42,6 @@ export const RootNavigator = memo(() => {
       )}
       <LoadingScreen />
       <RevertModal />
-      <ClaimRewardModal />
     </View>
   );
 });

--- a/frontend/app/navigation/RootNavigator.tsx
+++ b/frontend/app/navigation/RootNavigator.tsx
@@ -8,6 +8,7 @@ import { Header } from "../components/Header";
 import { InAppNotification } from "../components/InAppNotification";
 import { TutorialOverlay } from "../components/TutorialOverlay";
 import { RevertModal } from "../components/RevertModal";
+import { ClaimRewardModal } from "../components/ClaimRewardModal";
 import { LoadingScreen } from "../pages/LoadingScreen";
 
 import { useFocEngine } from "../context/FocEngineConnector";
@@ -43,6 +44,7 @@ export const RootNavigator = memo(() => {
       )}
       <LoadingScreen />
       <RevertModal />
+      <ClaimRewardModal />
     </View>
   );
 });

--- a/frontend/app/navigation/TabNavigator.tsx
+++ b/frontend/app/navigation/TabNavigator.tsx
@@ -326,7 +326,12 @@ export const TabNavigator = memo(() => {
 
       <Tab.Screen
         name="Settings"
-        children={(nav) => <SettingsPage setLoginPage={null} initialTab={(nav.route.params as any)?.initialTab} />}
+        children={(nav) => (
+          <SettingsPage
+            setLoginPage={null}
+            initialTab={(nav.route.params as any)?.initialTab}
+          />
+        )}
         options={{
           freezeOnBlur: true,
           tabBarButton: (props) => (

--- a/frontend/app/navigation/TabNavigator.tsx
+++ b/frontend/app/navigation/TabNavigator.tsx
@@ -326,7 +326,7 @@ export const TabNavigator = memo(() => {
 
       <Tab.Screen
         name="Settings"
-        children={() => <SettingsPage setLoginPage={null} />}
+        children={(nav) => <SettingsPage setLoginPage={null} initialTab={(nav.route.params as any)?.initialTab} />}
         options={{
           freezeOnBlur: true,
           tabBarButton: (props) => (

--- a/frontend/app/pages/MainPage.tsx
+++ b/frontend/app/pages/MainPage.tsx
@@ -5,6 +5,7 @@ import { L1Phase } from "./main/L1Phase";
 import { L2Phase } from "./main/L2Phase";
 import { MainBackground } from "../components/MainBackground";
 import { L1L2Switch } from "../components/L1L2Switch";
+import { ClaimRewardModal } from "../components/ClaimRewardModal";
 
 const MainPageComponent: React.FC = () => {
   const isL2Unlocked = useL2Store((state) => state.isL2Unlocked);
@@ -31,6 +32,7 @@ const MainPageComponent: React.FC = () => {
         />
       )}
       {currentView === "L2" ? <L2Phase /> : <L1Phase />}
+      <ClaimRewardModal />
     </View>
   );
 };

--- a/frontend/app/stores/useSoundStore.ts
+++ b/frontend/app/stores/useSoundStore.ts
@@ -131,7 +131,7 @@ interface SoundState {
   soundPool: SoundPool | null;
   isInitialized: boolean;
   currentTrackName: string | null;
-  lastPlayedTracks: string[];
+  lastPlayedTracks: (string | null)[];
 
   toggleSound: () => void;
   toggleMusic: () => Promise<void>;
@@ -371,7 +371,7 @@ export const useSoundStore = create<SoundState>((set, get) => ({
 
         newMusicPlayer.play();
       } else {
-        musicPlayer.play();
+        get().playNextTrack();
       }
     } catch (error) {
       if (__DEV__) console.error("Failed to play music:", error);

--- a/frontend/app/stores/useUpgradesStore.ts
+++ b/frontend/app/stores/useUpgradesStore.ts
@@ -9,7 +9,6 @@ import { FocAccount } from "../context/FocEngineConnector";
 import { useL2Store } from "./useL2Store";
 import { useTransactionsStore } from "./useTransactionsStore";
 import { useGameStore } from "./useGameStore";
-import { useOnchainActions } from "./useOnchainActions";
 
 interface UpgradesState {
   // Map: chainId -> upgradeId -> Upgrade Level
@@ -20,6 +19,8 @@ interface UpgradesState {
   canPrestige: boolean;
   isInitialized: boolean;
   setIsInitialized: (initialized: boolean) => void;
+  hasShownClaimModal: boolean;
+  setHasShownClaimModal: (hasShown: boolean) => void;
 
   // Actions
   upgrade: (chainId: number, upgradeId: number) => void;
@@ -73,6 +74,9 @@ export const useUpgradesStore = create<UpgradesState>((set, get) => ({
   canPrestige: false,
   isInitialized: false,
   setIsInitialized: (isInitialized: boolean) => set({ isInitialized }),
+  hasShownClaimModal: false,
+  setHasShownClaimModal: (hasShown: boolean) =>
+    set({ hasShownClaimModal: hasShown }),
 
   resetUpgrades: () => {
     // Initialize upgrades


### PR DESCRIPTION
  - Claim Reward Modal: New modal to direct user to the claim reward page. Uses AsyncStorage to prevent showing the claim reward modal to users who have already claimed their reward. Implemented direct navigation from the modal to the Settings page
  - Improved Music Playback: When resuming music, always go to next song