### PR TITLE
Patch `markNodeAsRemovable` error

### DIFF
--- a/frontend/babel.config.js
+++ b/frontend/babel.config.js
@@ -6,5 +6,8 @@ module.exports = function (api) {
       ["babel-preset-expo", { jsxImportSource: "nativewind" }],
       "nativewind/babel",
     ],
+    plugins: [
+      "react-native-reanimated/plugin"
+    ]
   };
 };

--- a/frontend/metro.config.ts
+++ b/frontend/metro.config.ts
@@ -1,7 +1,10 @@
 const { withNativeWind } = require("nativewind/metro");
 const { getSentryExpoConfig } = require("@sentry/react-native/metro");
+const {
+  wrapWithReanimatedMetroConfig,
+} = require('react-native-reanimated/metro-config');
 
-const config = getSentryExpoConfig(__dirname);
+let config = getSentryExpoConfig(__dirname);
 config.resolver.unstable_conditionNames = [
   "browser",
   "require",
@@ -12,4 +15,5 @@ config.resolver.extraNodeModules = {
   stream: require.resolve("readable-stream"),
 };
 
-module.exports = withNativeWind(config, { input: "./app/global.css" });
+config = withNativeWind(config, { input: "./app/global.css" });
+module.exports = wrapWithReanimatedMetroConfig(config);

--- a/frontend/metro.config.ts
+++ b/frontend/metro.config.ts
@@ -2,7 +2,7 @@ const { withNativeWind } = require("nativewind/metro");
 const { getSentryExpoConfig } = require("@sentry/react-native/metro");
 const {
   wrapWithReanimatedMetroConfig,
-} = require('react-native-reanimated/metro-config');
+} = require("react-native-reanimated/metro-config");
 
 let config = getSentryExpoConfig(__dirname);
 config.resolver.unstable_conditionNames = [

--- a/frontend/patches/react-native-reanimated+3.17.5.patch
+++ b/frontend/patches/react-native-reanimated+3.17.5.patch
@@ -1,0 +1,74 @@
+diff --git a/node_modules/react-native-reanimated/Common/cpp/reanimated/Fabric/PropsRegistry.cpp b/node_modules/react-native-reanimated/Common/cpp/reanimated/Fabric/PropsRegistry.cpp
+index d11f7fa..d472d87 100644
+--- a/node_modules/react-native-reanimated/Common/cpp/reanimated/Fabric/PropsRegistry.cpp
++++ b/node_modules/react-native-reanimated/Common/cpp/reanimated/Fabric/PropsRegistry.cpp
+@@ -41,22 +41,21 @@ void PropsRegistry::unmarkNodeAsRemovable(Tag viewTag) {
+ }
+ 
+ void PropsRegistry::handleNodeRemovals(const RootShadowNode &rootShadowNode) {
+-  for (auto it = removableShadowNodes_.begin();
+-       it != removableShadowNodes_.end();) {
+-    const auto &shadowNode = it->second;
+-    const auto &family = shadowNode->getFamily();
+-    const auto &ancestors = family.getAncestors(rootShadowNode);
++  RemovableShadowNodes remainingShadowNodes;
+ 
+-    // Skip if the node hasn't been removed
+-    if (!ancestors.empty()) {
+-      ++it;
++  for (const auto &[tag, shadowNode] : removableShadowNodes_) {
++    if (!shadowNode) {
+       continue;
+     }
+ 
+-    const auto tag = shadowNode->getTag();
+-    map_.erase(tag);
+-    it = removableShadowNodes_.erase(it);
++    if (shadowNode->getFamily().getAncestors(rootShadowNode).empty()) {
++      map_.erase(tag);
++    } else {
++      remainingShadowNodes.emplace(tag, shadowNode);
++    }
+   }
++
++  removableShadowNodes_ = std::move(remainingShadowNodes);
+ }
+ 
+ void PropsRegistry::remove(const Tag tag) {
+diff --git a/node_modules/react-native-reanimated/Common/cpp/reanimated/Fabric/PropsRegistry.h b/node_modules/react-native-reanimated/Common/cpp/reanimated/Fabric/PropsRegistry.h
+index 42a29b2..7523a2b 100644
+--- a/node_modules/react-native-reanimated/Common/cpp/reanimated/Fabric/PropsRegistry.h
++++ b/node_modules/react-native-reanimated/Common/cpp/reanimated/Fabric/PropsRegistry.h
+@@ -54,8 +54,11 @@ class PropsRegistry {
+   void handleNodeRemovals(const RootShadowNode &rootShadowNode);
+ 
+  private:
++  using RemovableShadowNodes =
++      std::unordered_map<Tag, std::shared_ptr<const ShadowNode>>;
++
+   std::unordered_map<Tag, std::pair<ShadowNode::Shared, folly::dynamic>> map_;
+-  std::unordered_map<Tag, ShadowNode::Shared> removableShadowNodes_;
++  RemovableShadowNodes removableShadowNodes_;
+ 
+   mutable std::mutex mutex_; // Protects `map_`.
+ 
+diff --git a/node_modules/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp b/node_modules/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+index f3742ed..9a0e683 100644
+--- a/node_modules/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
++++ b/node_modules/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+@@ -600,6 +600,7 @@ void ReanimatedModuleProxy::cleanupSensors() {
+ void ReanimatedModuleProxy::markNodeAsRemovable(
+     jsi::Runtime &rt,
+     const jsi::Value &shadowNodeWrapper) {
++  auto lock = propsRegistry_->createLock();
+   auto shadowNode = shadowNodeFromValue(rt, shadowNodeWrapper);
+   propsRegistry_->markNodeAsRemovable(shadowNode);
+ }
+@@ -607,6 +608,7 @@ void ReanimatedModuleProxy::markNodeAsRemovable(
+ void ReanimatedModuleProxy::unmarkNodeAsRemovable(
+     jsi::Runtime &rt,
+     const jsi::Value &viewTag) {
++  auto lock = propsRegistry_->createLock();
+   propsRegistry_->unmarkNodeAsRemovable(viewTag.asNumber());
+ }
+ 


### PR DESCRIPTION
With the same fashion with #181 patching reanimated package as described in this [PR](https://github.com/software-mansion/react-native-reanimated/pull/8005). 

The reason for patching instead of updating to `3.19.1` is that Expo GO is not compatible with this version, as expo on SDK 53 is bundled with `~3.17.4`. Since before each release we are building natively we can use this patch.

In addition, we seem to not employ all the installation instructions for 3.x as described [here](https://docs.swmansion.com/react-native-reanimated/docs/3.x/fundamentals/getting-started/#installation). Babel and metro configs are updated accordingly.