### PR TITLE
Update achievement logic to reset on Prestige upgrade

### DIFF
--- a/frontend/app/stores/useUpgradesStore.ts
+++ b/frontend/app/stores/useUpgradesStore.ts
@@ -492,6 +492,9 @@ export const useUpgradesStore = create<UpgradesState>((set, get) => ({
     useTransactionPauseStore.getState().resetPauseStore();
     get().resetUpgrades();
 
+    // Reset achievements except for Prestige!, Reach Max Prestige, and STRK Reward Claimed
+    await useAchievementsStore.getState().resetAchievementsOnPrestige();
+
     set({
       currentPrestige: nextPrestige,
       canPrestige: false,


### PR DESCRIPTION
Update achievement logic to reset all ach on Prestige upgrade except Prestige!, Reach Max Prestige, STRK Reward Claimed