### PR TITLE
Fix CI gem installation by using bundle install

### DIFF
--- a/.github/workflows/deploy-mobile.yml
+++ b/.github/workflows/deploy-mobile.yml
@@ -99,12 +99,12 @@ jobs:
               with:
                 ruby-version: '2.6'
 
-            - name: Update Gems
+            - name: Install Gems
               working-directory: ./frontend
               run: |
                 gem install bundler -v 2.4.22
                 bundle config path vendor/bundle
-                bundle update
+                bundle install
 
             - name: Upload to Firebase
               if: ${{ inputs.internal_testing == true }}
@@ -170,9 +170,9 @@ jobs:
               working-directory: ./frontend
               run: npm ci
 
-            - name: Update Gems
+            - name: Install Gems
               working-directory: ./frontend
-              run: bundle update
+              run: bundle install
 
             - name: Decode secrets
               working-directory: ./frontend


### PR DESCRIPTION
Changes bundle update to bundle install to respect Gemfile.lock. This prevents dependency resolution failures when external gems change.